### PR TITLE
Calculate collateral contract index before repayment tx satisfaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Always satisfy the collateral contract input in the loan repayment transaction correctly.
+  We used to assume that it was located at index `1`, but this could change if the number of inputs used to cover the repayment output was greater than 1.
+
 ## [0.2.0] - 2021-07-30
 
 ### Added

--- a/src/loan.rs
+++ b/src/loan.rs
@@ -744,6 +744,8 @@ impl Borrower1 {
             .map(|input| input.txin)
             .collect();
         tx_ins.push(collateral_input.txin);
+        let collateral_contract_index = (tx_ins.len() - 1) as u32;
+
         let tx_ins = tx_ins
             .into_iter()
             .map(|previous_output| TxIn {
@@ -816,7 +818,7 @@ impl Borrower1 {
             .satisfy_loan_repayment(
                 &mut tx,
                 self.repayment_collateral_input.original_txout.value,
-                1,
+                collateral_contract_index,
                 // TODO: Push ownership (and generation) of secret key outside of the library
                 |message| async move { Ok(SECP256K1.sign(&message, &self.keypair.0)) },
             )


### PR DESCRIPTION
Given that we can have multiple txins the loan contract might not always be at index position 1.
Since we push the loan contract txin into the vec as last element we can be sure it is the last element in the vec when we satisfy the loan repayment.