### PR TITLE
Add units indicator to Oracle message

### DIFF
--- a/rocket_sqlite_oracle/README.md
+++ b/rocket_sqlite_oracle/README.md
@@ -3,7 +3,7 @@
 Do:
 
 ```bash
-$ ROCKET_DATABASES='{oracle_signatures={url="./db/signatures.sqlite"}}' cargo run -- --secret="./dev_keys/oracle_secret"
+$ cargo run -- --secret="./dev_keys/oracle_secret"
 ```
 
 or generate a new key by setting `--generate-secret=true`

--- a/rocket_sqlite_oracle/Rocket.toml
+++ b/rocket_sqlite_oracle/Rocket.toml
@@ -1,2 +1,2 @@
-[default.databases.example_signatures]
+[default.databases.signatures]
 url = "./db/signatures.sqlite"

--- a/rocket_sqlite_oracle/migrations/20210803064311_create_tables.sql
+++ b/rocket_sqlite_oracle/migrations/20210803064311_create_tables.sql
@@ -1,6 +1,7 @@
 create table if not exists signatures (
     id              integer primary key autoincrement,
     timestamp       integer not null,
+    units           text    not null default "millicents",
     ask_price       integer not null,
     bid_price       integer not null,
     ask_signature   blob    not null,

--- a/rocket_sqlite_oracle/sqlx-data.json
+++ b/rocket_sqlite_oracle/sqlx-data.json
@@ -1,35 +1,5 @@
 {
   "db": "SQLite",
-  "1b786e5ca7e992518780e558515dccee0a7fda37dbc10b71ec33cef7cc95b10e": {
-    "query": "\n        select\n            timestamp,\n            ask_price as price,\n            ask_signature as signature\n        from signatures\n        order by timestamp desc\n        limit 1;\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "timestamp",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "price",
-          "ordinal": 1,
-          "type_info": "Int64"
-        },
-        {
-          "name": "signature",
-          "ordinal": 2,
-          "type_info": "Blob"
-        }
-      ],
-      "parameters": {
-        "Right": 0
-      },
-      "nullable": [
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "348c5471de83dac8f76a8e11732ea52f13243e03a8050857e93bf22da05cb751": {
     "query": "\n                        insert into signatures (\n                          timestamp,\n                          ask_price,\n                          bid_price,\n                          ask_signature,\n                          bid_signature\n                        ) values (?, ?, ?, ?, ?)",
     "describe": {
@@ -40,8 +10,8 @@
       "nullable": []
     }
   },
-  "7dfffbdeb32f6fcfbcc96a2ea1bf42f82b45b6dddd6c55faae88c57c30a0621c": {
-    "query": "\n        with above as (\n          select *\n          from signatures\n          where timestamp >= ?\n          order by timestamp\n          limit 1\n        ),\n\n        below as (\n          select *\n          from signatures\n          where timestamp < ?\n          order by timestamp desc\n          limit 1\n        ),\n\n        opts as (\n          select * from above\n          union all\n          select * from below\n        )\n\n        select\n          timestamp,\n          bid_price as price,\n          bid_signature as signature\n        from opts\n        order by abs(? - timestamp)\n        limit 1;\n        ",
+  "4fab760ba0880b8a35914b23eca4f0f6ec65cdf9c19a1de4142be16317a7bb95": {
+    "query": "\n        select\n            timestamp,\n            ask_price as price,\n            units,\n            ask_signature as signature\n        from signatures\n        order by timestamp desc\n        limit 1;\n        ",
     "describe": {
       "columns": [
         {
@@ -55,68 +25,13 @@
           "type_info": "Int64"
         },
         {
-          "name": "signature",
+          "name": "units",
           "ordinal": 2,
-          "type_info": "Blob"
-        }
-      ],
-      "parameters": {
-        "Right": 3
-      },
-      "nullable": [
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "931284ec445e69973e3edb5cd487a261bab4aa993e0f61a948e56f889e30d94a": {
-    "query": "\n        with above as (\n          select *\n          from signatures\n          where timestamp >= ?\n          order by timestamp\n          limit 1\n        ),\n\n        below as (\n          select *\n          from signatures\n          where timestamp < ?\n          order by timestamp desc\n          limit 1\n        ),\n\n        opts as (\n          select * from above\n          union all\n          select * from below\n        )\n\n        select\n          timestamp,\n          ask_price as price,\n          ask_signature as signature\n        from opts\n        order by abs(? - timestamp)\n        limit 1;\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "timestamp",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "price",
-          "ordinal": 1,
-          "type_info": "Int64"
+          "type_info": "Text"
         },
         {
           "name": "signature",
-          "ordinal": 2,
-          "type_info": "Blob"
-        }
-      ],
-      "parameters": {
-        "Right": 3
-      },
-      "nullable": [
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "a987447e32fd5d1cccc3316b2253054acfc6924e9a49c42d61b226379dbd1ab7": {
-    "query": "\n        select\n            timestamp,\n            bid_price as price,\n            bid_signature as signature\n        from signatures\n        order by timestamp desc\n        limit 1;\n        ",
-    "describe": {
-      "columns": [
-        {
-          "name": "timestamp",
-          "ordinal": 0,
-          "type_info": "Int64"
-        },
-        {
-          "name": "price",
-          "ordinal": 1,
-          "type_info": "Int64"
-        },
-        {
-          "name": "signature",
-          "ordinal": 2,
+          "ordinal": 3,
           "type_info": "Blob"
         }
       ],
@@ -124,6 +39,115 @@
         "Right": 0
       },
       "nullable": [
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "730103c0ec907bb62f7d33fede149128e1b14b6f3c48e77fa4e949aec2dbc174": {
+    "query": "\n        with above as (\n          select *\n          from signatures\n          where timestamp >= ?\n          order by timestamp\n          limit 1\n        ),\n\n        below as (\n          select *\n          from signatures\n          where timestamp < ?\n          order by timestamp desc\n          limit 1\n        ),\n\n        opts as (\n          select * from above\n          union all\n          select * from below\n        )\n\n        select\n          timestamp,\n          bid_price as price,\n          units,\n          bid_signature as signature\n        from opts\n        order by abs(? - timestamp)\n        limit 1;\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "timestamp",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "price",
+          "ordinal": 1,
+          "type_info": "Int64"
+        },
+        {
+          "name": "units",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "signature",
+          "ordinal": 3,
+          "type_info": "Blob"
+        }
+      ],
+      "parameters": {
+        "Right": 3
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "a3c91fd272ec52eab69f62864312bd7ed7afdffcbe6fe289b16a8b0f11fd3179": {
+    "query": "\n        with above as (\n          select *\n          from signatures\n          where timestamp >= ?\n          order by timestamp\n          limit 1\n        ),\n\n        below as (\n          select *\n          from signatures\n          where timestamp < ?\n          order by timestamp desc\n          limit 1\n        ),\n\n        opts as (\n          select * from above\n          union all\n          select * from below\n        )\n\n        select\n          timestamp,\n          ask_price as price,\n          units,\n          ask_signature as signature\n        from opts\n        order by abs(? - timestamp)\n        limit 1;\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "timestamp",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "price",
+          "ordinal": 1,
+          "type_info": "Int64"
+        },
+        {
+          "name": "units",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "signature",
+          "ordinal": 3,
+          "type_info": "Blob"
+        }
+      ],
+      "parameters": {
+        "Right": 3
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "ec570afc805668e99e9cf877b59bdb57d45fbd73058f95637c9f11535436bbd9": {
+    "query": "\n        select\n            timestamp,\n            bid_price as price,\n            units,\n            bid_signature as signature\n        from signatures\n        order by timestamp desc\n        limit 1;\n        ",
+    "describe": {
+      "columns": [
+        {
+          "name": "timestamp",
+          "ordinal": 0,
+          "type_info": "Int64"
+        },
+        {
+          "name": "price",
+          "ordinal": 1,
+          "type_info": "Int64"
+        },
+        {
+          "name": "units",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "signature",
+          "ordinal": 3,
+          "type_info": "Blob"
+        }
+      ],
+      "parameters": {
+        "Right": 0
+      },
+      "nullable": [
+        false,
         false,
         false,
         false

--- a/rocket_sqlite_oracle/src/db/kraken.rs
+++ b/rocket_sqlite_oracle/src/db/kraken.rs
@@ -257,7 +257,7 @@ mod wire {
 
     #[derive(Debug, Clone)]
     pub struct USDPrice {
-        pub millicents: u64,
+        pub exchange_rate: u64,
     }
 
     /// Represents an update within the price ticker.
@@ -302,7 +302,7 @@ mod wire {
             let dec = Decimal::from_str(s).unwrap().to_u64().unwrap();
             let dec = dec * 10_000;
 
-            Ok(USDPrice { millicents: dec })
+            Ok(USDPrice { exchange_rate: dec })
         }
     }
 

--- a/rocket_sqlite_oracle/src/main.rs
+++ b/rocket_sqlite_oracle/src/main.rs
@@ -23,6 +23,7 @@ async fn current_ask_price(mut conn: Connection<db::Signatures>) -> Json<db::USD
         select
             timestamp,
             ask_price as price,
+            units,
             ask_signature as signature
         from signatures
         order by timestamp desc
@@ -35,6 +36,7 @@ async fn current_ask_price(mut conn: Connection<db::Signatures>) -> Json<db::USD
     let res = db::USDTickerResponse {
         timestamp: row.timestamp.try_into().unwrap(),
         price: row.price.try_into().unwrap(),
+        units: row.units,
         signature: Signature::from_compact(&row.signature).unwrap(),
     };
 
@@ -48,6 +50,7 @@ async fn current_bid_price(mut conn: Connection<db::Signatures>) -> Json<db::USD
         select
             timestamp,
             bid_price as price,
+            units,
             bid_signature as signature
         from signatures
         order by timestamp desc
@@ -60,6 +63,7 @@ async fn current_bid_price(mut conn: Connection<db::Signatures>) -> Json<db::USD
     let res = db::USDTickerResponse {
         timestamp: row.timestamp.try_into().unwrap(),
         price: row.price.try_into().unwrap(),
+        units: row.units,
         signature: Signature::from_compact(&row.signature).unwrap(),
     };
 
@@ -98,6 +102,7 @@ async fn ask_price_at_time(
         select
           timestamp,
           ask_price as price,
+          units,
           ask_signature as signature
         from opts
         order by abs(? - timestamp)
@@ -113,6 +118,7 @@ async fn ask_price_at_time(
     let res = db::USDTickerResponse {
         timestamp: row.timestamp.try_into().unwrap(),
         price: row.price.try_into().unwrap(),
+        units: row.units,
         signature: Signature::from_compact(&row.signature).unwrap(),
     };
 
@@ -151,6 +157,7 @@ async fn bid_price_at_time(
         select
           timestamp,
           bid_price as price,
+          units,
           bid_signature as signature
         from opts
         order by abs(? - timestamp)
@@ -166,6 +173,7 @@ async fn bid_price_at_time(
     let res = db::USDTickerResponse {
         timestamp: row.timestamp.try_into().unwrap(),
         price: row.price.try_into().unwrap(),
+        units: row.units,
         signature: Signature::from_compact(&row.signature).unwrap(),
     };
 

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -2,7 +2,8 @@ use elements::hashes::{sha256, Hash, HashEngine};
 use elements::secp256k1_zkp::{self, SECP256K1};
 
 pub struct Message {
-    /// Price of bitcoin in whole USD.
+    /// Price of bitcoin in millicents, where
+    /// USD1.00 = 10_000 millicents.
     btc_price: WitnessStackInteger,
     /// UNIX timestamp.
     timestamp: WitnessStackInteger,


### PR DESCRIPTION
For price-signalled liquidation to work properly, the consumer
of the oracle message(s) must know what exchange-rate units the
oracle is using. This PR adds a filed "units" the JSON response
and in the documentation (comments in oracle.rs) indicates that
the sample oracle is using millicents. Values remain integers.

Additionally, a typo was discovered in Rocket.toml that has been
fixed up.

Resolves: #53