### PR TITLE
Do not attempt to construct 0-amount `TxOut`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The loan transaction no longer expects collateral and principal change outputs.
+  We were unconditionally adding them to the transaction which could result in attempting to [build a 0-valued confidential transaction output, which is invalid](https://github.com/comit-network/baru/issues/38).
+
 ## [0.3.0] - 2021-08-06
 
 ### Added

--- a/tests/loan_protocol.rs
+++ b/tests/loan_protocol.rs
@@ -39,7 +39,13 @@ async fn borrow_and_repay() {
             &mut rng,
             {
                 let wallet = &mut wallet;
-                |amount, asset| async move { wallet.coin_select(amount, asset) }
+                |amount, asset| async move {
+                    wallet.coin_select(
+                        // we need extra coins to pay for the fee
+                        amount + Amount::from_sat(10_000),
+                        asset,
+                    )
+                }
             },
             address,
             blinding_sk,
@@ -173,7 +179,13 @@ async fn lend_and_liquidate() {
             &mut rng,
             {
                 let wallet = &mut wallet;
-                |amount, asset| async move { wallet.coin_select(amount, asset) }
+                |amount, asset| async move {
+                    wallet.coin_select(
+                        // we need extra coins to pay for the fee
+                        amount + Amount::from_sat(10_000),
+                        asset,
+                    )
+                }
             },
             address,
             blinding_sk,
@@ -284,7 +296,13 @@ async fn lend_and_dynamic_liquidate() {
             &mut rng,
             {
                 let wallet = &mut wallet;
-                |amount, asset| async move { wallet.coin_select(amount, asset) }
+                |amount, asset| async move {
+                    wallet.coin_select(
+                        // we need extra coins to pay for the fee
+                        amount + Amount::from_sat(10_000),
+                        asset,
+                    )
+                }
             },
             address,
             blinding_sk,
@@ -495,6 +513,156 @@ async fn lend_and_dynamic_liquidate() {
         )
         .expect("dynamic liquidation transaction to spend collateral correctly");
     }
+}
+
+#[tokio::test]
+async fn can_run_protocol_with_principal_change_outputs() {
+    let mut rng = ChaChaRng::seed_from_u64(0);
+
+    let bitcoin_asset_id = "0c5d451941f37b801d04c46920f2bc5bbd3986e5f56cb56c6b17bedc655e9fc6"
+        .parse()
+        .unwrap();
+    let usdt_asset_id = "6b397062b69411b554ec398ae3b25fdc54fab1805126786581a56a7746afbab2"
+        .parse()
+        .unwrap();
+    let (_oracle_sk, oracle_pk) = make_keypair(&mut rng);
+
+    let mut wallet = Wallet::default();
+    let borrower = {
+        let (_sk, pk) = make_keypair(&mut rng);
+        let (blinding_sk, blinding_pk) = make_keypair(&mut rng);
+        let address = Address::p2pkh(&pk, Some(blinding_pk.key), &AddressParams::LIQUID);
+
+        let collateral_amount = Amount::ONE_BTC;
+
+        Borrower0::new(
+            &mut rng,
+            {
+                let wallet = &mut wallet;
+                |amount, asset| async move {
+                    wallet.coin_select(
+                        // we need extra coins to pay for the fee
+                        amount + Amount::from_sat(10_000),
+                        asset,
+                    )
+                }
+            },
+            address,
+            blinding_sk,
+            collateral_amount,
+            Amount::ONE_SAT,
+            bitcoin_asset_id,
+            usdt_asset_id,
+        )
+        .await
+        .unwrap()
+    };
+
+    let (lender, _lender_address) = {
+        let (_sk, pk) = make_keypair(&mut rng);
+        let (blinding_sk, blinding_pk) = make_keypair(&mut rng);
+        let address = Address::p2pkh(&pk, Some(blinding_pk.key), &AddressParams::LIQUID);
+
+        let lender = Lender0::new(
+            &mut rng,
+            bitcoin_asset_id,
+            usdt_asset_id,
+            address.clone(),
+            blinding_sk,
+            oracle_pk,
+        )
+        .unwrap();
+
+        (lender, address)
+    };
+
+    let timelock = 10;
+    let principal_amount = Amount::from_btc(38_000.0).unwrap();
+    let principal_inputs = wallet
+        .coin_select(
+            // force presence of principal change output by providing
+            // more coins than necessary
+            principal_amount + Amount::from_sat(10_000),
+            usdt_asset_id,
+        )
+        .unwrap();
+    let repayment_amount = principal_amount + Amount::from_btc(1_000.0).unwrap();
+    let min_collateral_price = 38_000;
+
+    let lender = lender
+        .build_loan_transaction(
+            &mut rng,
+            SECP256K1,
+            borrower.fee_sats_per_vbyte(),
+            (
+                *borrower.collateral_amount(),
+                borrower.collateral_inputs().to_vec(),
+            ),
+            (principal_amount, principal_inputs),
+            repayment_amount,
+            min_collateral_price,
+            (borrower.pk(), borrower.address().clone()),
+            timelock,
+        )
+        .await
+        .unwrap();
+    let loan_response = lender.loan_response();
+
+    let borrower = borrower.interpret(SECP256K1, loan_response).unwrap();
+    let loan_transaction = borrower
+        .sign(|tx| async { Ok(wallet.sign_inputs(tx)) })
+        .await
+        .unwrap();
+
+    let loan_transaction = lender
+        .finalise_loan(loan_transaction, {
+            |tx| async { Ok(wallet.sign_inputs(tx)) }
+        })
+        .await
+        .unwrap();
+
+    wallet
+        .verify_wallet_transaction(&loan_transaction)
+        .expect("loan transaction to be correctly signed");
+
+    // only the repayment branch could add change outputs, so we ignore the others
+    let wallet = Arc::new(Mutex::new(wallet.clone()));
+    let loan_repayment_transaction = borrower
+        .loan_repayment_transaction(
+            &mut rng,
+            SECP256K1,
+            {
+                let wallet = wallet.clone();
+                |amount, asset| async move {
+                    let mut wallet = wallet.lock().unwrap();
+                    // force presence of principal change output by providing
+                    // more coins than necessary
+                    wallet.coin_select(amount + Amount::from_sat(10_000), asset)
+                }
+            },
+            {
+                let wallet = wallet.clone();
+                |tx| async move {
+                    let wallet = wallet.lock().unwrap();
+                    Ok(wallet.sign_inputs(tx))
+                }
+            },
+            Amount::ONE_SAT,
+        )
+        .await
+        .unwrap();
+
+    let wallet_inputs = {
+        let wallet = wallet.lock().unwrap();
+        &wallet.used_txouts(&loan_repayment_transaction)
+    };
+    verify_spend_transaction(
+        &loan_repayment_transaction,
+        &loan_transaction,
+        borrower.collateral_contract(),
+        wallet_inputs,
+    )
+    .expect("repayment transaction to spend collateral correctly");
 }
 
 fn verify_spend_transaction(

--- a/tests/swap_happy_path.rs
+++ b/tests/swap_happy_path.rs
@@ -74,7 +74,7 @@ async fn collaborative_create_and_sign() {
             .unwrap();
 
     wallet
-        .verify_all_inputs_spend_correctly(&transaction)
+        .verify_wallet_transaction(&transaction)
         .expect("to have correctly signed all inputs");
 }
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -29,10 +29,16 @@ impl Wallet {
         let spent_utxo_secrets = {
             let abf = AssetBlindingFactor::new(&mut rng);
             let vbf = ValueBlindingFactor::new(&mut rng);
-            let secrets = TxOutSecrets::new(asset, abf, amount.as_sat(), vbf);
-            let asset = Asset::new_confidential(SECP256K1, asset, abf);
 
-            [(asset, secrets)]
+            // we don't have to prove the entire history of these
+            // coins, so any value works here
+            let value = 0;
+
+            let secrets = TxOutSecrets::new(asset, abf, value, vbf);
+
+            let asset_commitment = Asset::new_confidential(SECP256K1, asset, abf);
+
+            [(asset_commitment, secrets)]
         };
 
         let (original_txout, _, _) = TxOut::new_last_confidential(

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -19,6 +19,10 @@ pub struct Wallet {
 }
 
 impl Wallet {
+    /// Select inputs to pay for `amount` of `asset`.
+    ///
+    /// The corresponding UTXOs are generated ad hoc and subsequently
+    /// stored in the internal state of the wallet.
     pub fn coin_select(&mut self, amount: Amount, asset: AssetId) -> Result<Vec<Input>> {
         let mut rng = thread_rng();
 
@@ -44,7 +48,7 @@ impl Wallet {
         let (original_txout, _, _) = TxOut::new_last_confidential(
             &mut rng,
             SECP256K1,
-            amount.as_sat() + 10_000,
+            amount.as_sat(),
             address,
             asset,
             spent_utxo_secrets


### PR DESCRIPTION
Fix #38.

On the way, I noticed that after replacing the blockchain-based testing with `elements-consensus` (PR #34) we were no longer verifying that our transactions were not printing (or destroying) money. That's the motivation for https://github.com/comit-network/baru/commit/b005a04bf9bb8c3a1fc9bf9baa8d5812cd5cc080.

Please review patch by patch.