### PR TITLE
Force users to explicitly choose timelock types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The provided wallet comes with a UTXO cache which this is updated using `Wallet::sync`.
   This allows users of the library to optimise the number of requests to their backend.
   Users can also sign said UTXOs by calling `Wallet::sign`.
+- `Timelock` type to allow users of the library to explicitly choose the type of timelock they want to use when building the loan transaction.
+  For the time being, users can still pass in a `u32`, but they are encouraged not to.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.3.0"
 authors = ["CoBloX Team <team@coblox.tech>"]
 edition = "2018"
 license-file = "LICENSE"
+resolver = "2"
 description = "Library to facilitate DeFi on Liquid"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = "1"
 [dev-dependencies]
 elements-consensus = { git = "https://github.com/comit-network/rust-elements-consensus", rev = "ac88dbedcd019eef44f58499417dcdbeda994b0b" }
 link-cplusplus = "1"
+proptest = { version = "1", default-features = false, features = ["std"] }
 rand_chacha = "0.1"
 serde_json = "1"
 tokio = { version = "1", default-features = false, features = ["macros", "rt"] }

--- a/tests/loan_protocol.rs
+++ b/tests/loan_protocol.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
 use anyhow::{Context, Result};
-use baru::loan::{Borrower0, CollateralContract, Lender0};
+use baru::loan::{Borrower0, CollateralContract, Lender0, Timelock};
 use baru::oracle;
 use elements::bitcoin::Amount;
 use elements::secp256k1_zkp::SECP256K1;
@@ -72,7 +72,7 @@ async fn borrow_and_repay() {
         (lender, address)
     };
 
-    let timelock = 10;
+    let timelock = Timelock::new_block_height(10).unwrap();
     let principal_amount = Amount::from_btc(38_000.0).unwrap();
     let principal_inputs = wallet.coin_select(principal_amount, usdt_asset_id).unwrap();
     let repayment_amount = principal_amount + Amount::from_btc(1_000.0).unwrap();
@@ -208,7 +208,7 @@ async fn lend_and_liquidate() {
         (lender, address)
     };
 
-    let timelock = 10;
+    let timelock = Timelock::new_block_height(10).unwrap();
     let principal_amount = Amount::from_btc(38_000.0).unwrap();
     let principal_inputs = wallet.coin_select(principal_amount, usdt_asset_id).unwrap();
     let repayment_amount = principal_amount + Amount::from_btc(1_000.0).unwrap();
@@ -321,7 +321,7 @@ async fn lend_and_dynamic_liquidate() {
         (lender, address)
     };
 
-    let timelock = 10;
+    let timelock = Timelock::new_block_height(10).unwrap();
     let principal_amount = Amount::from_btc(38_000.0).unwrap();
     let principal_inputs = wallet.coin_select(principal_amount, usdt_asset_id).unwrap();
     let repayment_amount = principal_amount + Amount::from_btc(1_000.0).unwrap();
@@ -561,7 +561,7 @@ async fn can_run_protocol_with_principal_change_outputs() {
         (lender, address)
     };
 
-    let timelock = 10;
+    let timelock = Timelock::new_block_height(10).unwrap();
     let principal_amount = Amount::from_btc(38_000.0).unwrap();
     let principal_inputs = wallet
         .coin_select(


### PR DESCRIPTION
Fixes #41.

After reading #41 I thought that it could be useful to force users to explicitly choose the kind of absolute timelock they want in their collateral output. This way they can never be surprised by the behaviour of the protocol and they don't need to understand the inner workings of `OP_CLTV`.